### PR TITLE
Remove dependsOn from backstage

### DIFF
--- a/backstage.yaml
+++ b/backstage.yaml
@@ -18,8 +18,6 @@ spec:
   lifecycle: production
   providesApis:
     - PXWEB-API-V0
-  dependsOn:
-    - resource:job-db
 ---
 apiVersion: backstage.io/v1alpha1
 kind: API


### PR DESCRIPTION
A dependsOn was added by mistake on the pxweb Component in the initial backstage.yaml.