### PR TITLE
Update backstage.yaml to fix errors in backstage

### DIFF
--- a/backstage.yaml
+++ b/backstage.yaml
@@ -10,7 +10,7 @@ metadata:
     - .NET
     - Oracle
   annotations:
-    github.com/project-slug: 
+    github.com/project-slug: statisticsnorway/PxWeb
 spec:
   type: website
   system: PXWEB
@@ -25,9 +25,9 @@ metadata:
   name: PXWEB-API-V0
   description: API data and metadata statbank
 spec:
-  type: openapi
+  type: custom
   system: PXWEB
   owner: statbank-developers
   lifecycle: production
-  definition:
-    $text: 
+  definition: "N/A"
+  


### PR DESCRIPTION
The backstage system gets alot of errors because the backstage.yaml file is missing parts. This tries to fix those issues.

However, the spec.definition and spec.type of the API are required, but we do not have the spec/definition for them. So not sure if these will work.