### PR TITLE
Normalize tag casing in backstage.yaml

### DIFF
--- a/backstage.yaml
+++ b/backstage.yaml
@@ -6,8 +6,8 @@ metadata:
   description: |
     web page statbank
   tags:
-    - "C#"
-    - .NET
+    - c-sharp
+    - dotnet
     - Oracle
   annotations:
     github.com/project-slug: statisticsnorway/PxWeb

--- a/backstage.yaml
+++ b/backstage.yaml
@@ -6,9 +6,9 @@ metadata:
   description: |
     web page statbank
   tags:
-    - c-sharp
+    - csharp
     - dotnet
-    - Oracle
+    - oracle
   annotations:
     github.com/project-slug: statisticsnorway/PxWeb
 spec:


### PR DESCRIPTION
There seems to be a problem with our current tags and newer versions of backstage. This normalizes the tags to what was suggested by John Kasper Svergja skyinfra team